### PR TITLE
AIBot page at /aibot + agent router metadata + verbose response logging

### DIFF
--- a/backend/api/agent/router.py
+++ b/backend/api/agent/router.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import time
@@ -92,7 +93,8 @@ def _chunk_from_hit(hit: Dict[str, Any], language: str) -> Dict[str, Any]:
     except (TypeError, ValueError):
         score = 0.0
 
-    return {
+    chunk_labels = source.get("chunk_labels", {})
+    result = {
         "chunk_id": hit.get("_id") or source.get("chunk_id"),
         "text_content": source.get(text_field, ""),
         "category": metadata.get("category"),
@@ -100,13 +102,24 @@ def _chunk_from_hit(hit: Dict[str, Any], language: str) -> Dict[str, Any]:
         "author": _first_value(metadata, ["Author", "Tikakaar", "Teekakar", "Bhasha Vachanika"]),
         "anuyog": _first_value(metadata, ["Anuyog", "anuyog"]),
         "language": source.get("language", language),
-        "date": source.get("chunk_labels", {}).get("date"),
-        "pravachan_number": source.get("chunk_labels", {}).get("pravachan_number"),
-        "gatha": source.get("chunk_labels", {}).get("gatha"),
+        "date": chunk_labels.get("date"),
+        "pravachan_number": chunk_labels.get("pravachan_number"),
+        "gatha": chunk_labels.get("gatha"),
+        "kalash": chunk_labels.get("kalash"),
+        "shlok": chunk_labels.get("shlok"),
+        "volume": metadata.get("volume"),
+        "series_start_date": metadata.get("series_start_date"),
+        "series_end_date": metadata.get("series_end_date"),
         "page_number": source.get("page_number"),
         "file_url": metadata.get("file_url", ""),
         "score": score,
     }
+    if "Kanji" in metadata.get("Pravachankar", {}):
+        if language == "gu":
+            result["Pravachankar"] = "પૂજ્ય ગુરુદેવશ્રી કાનજી સ્વામી, સોનગઢ"
+        else:
+            result["Pravachankar"] = "पूज्य गुरुदेवश्री कानजी स्वामी"
+    return result
 
 
 def _build_date_range_filter(year_from: Optional[int], year_to: Optional[int]) -> Optional[Dict[str, Any]]:
@@ -308,6 +321,15 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             (getattr(request.client, 'host', 'unknown') if request.client else 'unknown')
         )
 
+        def _respond(results: list, mode: str, reranked: bool):
+            _log_metrics(results, mode, reranked)
+            log_handle.verbose(
+                "agent_search response query_id=%s mode=%s results=%s",
+                get_query_id(), mode,
+                json.dumps(results, ensure_ascii=False),
+            )
+            return JSONResponse(content=results, status_code=200)
+
         def _log_metrics(results: list, mode: str, reranked: bool) -> None:
             latency_ms = round((time.time() - start_time) * 1000, 2)
             escaped_q = payload.query.replace(',', ';').replace('"', "'").replace('\n', ' ').replace('\r', '')
@@ -358,8 +380,7 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             query_embedding = embedding_model.get_embedding(payload.query)
             if not query_embedding:
                 log_handle.warning("agent_search RRF produced empty embedding; returning empty results")
-                _log_metrics([], "rrf", False)
-                return JSONResponse(content=[], status_code=200)
+                return _respond([], "rrf", False)
 
             oversample = config._agent_config["rerank_oversample"]
 
@@ -427,8 +448,7 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             paginated = fused[from_:from_ + payload.page_size]
             results = [_chunk_from_hit(item["_hit"], payload.language) for item in paginated]
             _shorten_results(results, request.app.state.shortener_store, request.app.state.shortener_base_url)
-            _log_metrics(results, "rrf", payload.rerank and bool(index_searcher._reranker))
-            return JSONResponse(content=results, status_code=200)
+            return _respond(results, "rrf", payload.rerank and bool(index_searcher._reranker))
 
         # --- Lexical mode ---
         if is_lexical:
@@ -450,15 +470,13 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             log_handle.info("agent_search lexical hits=%s", len(hits))
             results = [_chunk_from_hit(hit, payload.language) for hit in hits]
             _shorten_results(results, request.app.state.shortener_store, request.app.state.shortener_base_url)
-            _log_metrics(results, "lexical", False)
-            return JSONResponse(content=results, status_code=200)
+            return _respond(results, "lexical", False)
 
         # --- Vector mode ---
         query_embedding = embedding_model.get_embedding(payload.query)
         if not query_embedding:
             log_handle.warning("agent_search produced empty embedding; returning empty results")
-            _log_metrics([], "vector", False)
-            return JSONResponse(content=[], status_code=200)
+            return _respond([], "vector", False)
 
         initial_fetch_size = config._agent_config["rerank_oversample"] if payload.rerank else payload.page_size
         knn_query = {"vector_embedding": {"vector": query_embedding, "k": initial_fetch_size}}
@@ -480,8 +498,7 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             paginated = hits[from_:from_ + payload.page_size]
             results = [_chunk_from_hit(hit, payload.language) for hit in paginated]
             _shorten_results(results, request.app.state.shortener_store, request.app.state.shortener_base_url)
-            _log_metrics(results, "vector", False)
-            return JSONResponse(content=results, status_code=200)
+            return _respond(results, "vector", False)
 
         sentence_pairs = []
         for hit in hits:
@@ -500,8 +517,7 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
             paginated = hits[from_:from_ + payload.page_size]
             results = [_chunk_from_hit(hit, payload.language) for hit in paginated]
             _shorten_results(results, request.app.state.shortener_store, request.app.state.shortener_base_url)
-            _log_metrics(results, "vector", False)
-            return JSONResponse(content=results, status_code=200)
+            return _respond(results, "vector", False)
         for hit, score in zip(hits, rerank_scores):
             hit["rerank_score"] = score
 
@@ -509,8 +525,7 @@ async def agent_search(request: Request, payload: AgentSearchRequest = Body(...)
         paginated_hits = reranked_hits[from_:from_ + payload.page_size]
         results = [_chunk_from_hit(hit, payload.language) for hit in paginated_hits]
         _shorten_results(results, request.app.state.shortener_store, request.app.state.shortener_base_url)
-        _log_metrics(results, "vector", True)
-        return JSONResponse(content=results, status_code=200)
+        return _respond(results, "vector", True)
 
     except Exception as exc:
         log_handle.exception(f"Agent search failed: {exc}")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -289,6 +289,23 @@ const AppContent = () => {
     }, []);
 
     useEffect(() => {
+        if (currentPage === 'home') {
+            document.title = 'Swa Lakshya (स्व-लक्ष्य)';
+            return;
+        }
+        const overrides = {
+            'aibot':        'AI Bot',
+            'search-index': 'Content',
+            'usage-guide':  'Usage Guide',
+            'whats-new':    "What's New",
+            'developer':    'Developer APIs',
+        };
+        const label = overrides[currentPage] ||
+            currentPage.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+        document.title = `Swalakshya · ${label}`;
+    }, [currentPage]);
+
+    useEffect(() => {
         api.getAppConfig().then(cfg => {
             setDebugMode(cfg.debug_mode);
             setActiveCategories(cfg.active_categories);
@@ -1502,6 +1519,7 @@ const AppContent = () => {
 
 // Admin route wrapper — persists session token in localStorage (survives tab close, expires after 1 day)
 function AdminRoute() {
+    React.useEffect(() => { document.title = 'Swalakshya · Admin'; }, []);
     const [token, setToken] = React.useState(() => localStorage.getItem('adminToken'));
     const handleAuth = (t) => { localStorage.setItem('adminToken', t); setToken(t); };
     const handleLogout = () => { localStorage.removeItem('adminToken'); setToken(null); };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -144,6 +144,7 @@ const AppContent = () => {
         if (path === '/usage-guide') return 'usage-guide';
         if (path === '/search-index') return 'search-index';
         if (path === '/eval') return 'eval';
+        if (path === '/aibot') return 'aibot';
         return 'home'; // Default to 'home' for root path
     });
     
@@ -162,6 +163,9 @@ const AppContent = () => {
             setCurrentPageState('search-index');
         } else if (path === '/eval') {
             setCurrentPageState('eval');
+        } else if (path === '/aibot') {
+            setCurrentPageState('aibot');
+            setHomeMode('chat');
         } else if (path === '/') {
             setCurrentPageState('home');
         }
@@ -275,7 +279,7 @@ const AppContent = () => {
     const PAGE_SIZE = 20;
     const llmProvider = (process.env.REACT_APP_LLM_PROVIDER || '').trim();
     const [llmAvailable, setLlmAvailable] = useState(false);
-    const [homeMode, setHomeMode] = useState('search');
+    const [homeMode, setHomeMode] = useState(() => location.pathname === '/aibot' ? 'chat' : 'search');
     const isChatMode = homeMode === 'chat';
     const chatEnabled = isChatMode;
     const showAnswerButton = llmAvailable && isChatMode;
@@ -760,7 +764,7 @@ const AppContent = () => {
 
     const paginatedSimilarResults = getPaginatedResults(similarDocumentsData?.results, similarDocsPage);
 
-    const showSearchInterface = currentPage === 'home';
+    const showSearchInterface = currentPage === 'home' || (currentPage === 'aibot' && llmAvailable);
 
     const cleanAnswerText = (answerText) => {
         if (!answerText) return '';
@@ -994,24 +998,21 @@ const AppContent = () => {
                 <div className="max-w-[1080px] mx-auto">
                     <Header currentPage={currentPage} />
 
+                    {currentPage === 'aibot' && !llmAvailable && (
+                        <main>
+                            <div className="text-center py-16">
+                                <p className="text-slate-500 text-lg">AI Service is unavailable right now.</p>
+                            </div>
+                        </main>
+                    )}
+
                     {showSearchInterface && (
                         <main>
-                            {llmAvailable && !isChatMode && (
-                                <div className="flex items-center justify-between bg-lime-50 border border-lime-200 rounded-lg px-4 py-2.5 mb-4 text-sm">
-                                    <span className="text-lime-800">✨ AI Chat (beta) is available.</span>
-                                    <button
-                                        onClick={() => setHomeMode('chat')}
-                                        className="ml-4 flex-shrink-0 bg-lime-600 hover:bg-lime-700 text-white text-xs font-semibold px-3 py-1.5 rounded-md transition-colors"
-                                    >
-                                        Try it
-                                    </button>
-                                </div>
-                            )}
 
                             {isChatMode && (
                                 <div className="flex items-center mb-4 text-sm">
                                     <button
-                                        onClick={() => setHomeMode('search')}
+                                        onClick={() => currentPage === 'aibot' ? navigate('/') : setHomeMode('search')}
                                         className="text-slate-500 hover:text-slate-700 flex items-center gap-1 transition-colors"
                                     >
                                         ← Back to Search
@@ -1521,6 +1522,7 @@ export default function App() {
                 <Route path="/search-index" element={<AppContent />} />
                 <Route path="/eval" element={<AppContent />} />
                 <Route path="/developer" element={<AppContent />} />
+                <Route path="/aibot" element={<AppContent />} />
                 <Route path="/admin" element={<AdminRoute />} />
             </Routes>
         </Router>


### PR DESCRIPTION
## Summary
- Add `/aibot` as a dedicated, unlisted route that opens directly in AI Chat mode; shows \"AI Service is unavailable right now.\" if LLM is down
- Remove the \"AI Chat (beta) is available\" banner from the home page so chat is only accessible via `/aibot`
- Expand `_chunk_from_hit` in `agent/router.py` to return `kalash`, `shlok`, `volume`, `series_start_date`, `series_end_date`, and `Pravachankar` — previously these were missing from agent search responses
- Add verbose response logging to all `agent_search` return paths (query_id + full result JSON via `_respond` helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)