### PR TITLE
Fix /aibot PDF page mapping

### DIFF
--- a/backend/api/agent/router.py
+++ b/backend/api/agent/router.py
@@ -113,6 +113,7 @@ def _chunk_from_hit(hit: Dict[str, Any], language: str) -> Dict[str, Any]:
         "series_start_date": metadata.get("series_start_date"),
         "series_end_date": metadata.get("series_end_date"),
         "page_number": source.get("page_number"),
+        "pdf_page_number": source.get("pdf_page_number"),
         "file_url": metadata.get("file_url", ""),
         "score": score,
     }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1387,6 +1387,14 @@ const AppContent = () => {
         };
     };
 
+    const buildReferencePdfUrl = (fileUrl, pdfPageNumber, fallbackPageNumber) => {
+        const url = String(fileUrl || '').trim();
+        const page = Number(pdfPageNumber ?? fallbackPageNumber);
+        if (!url) return null;
+        if (!Number.isFinite(page) || page <= 0) return url;
+        return url.endsWith(`/${page}`) ? url : `${url}/${page}`;
+    };
+
     const getCitationCategoryMeta = (category) => {
         switch (category) {
             case 'Pravachan':
@@ -1479,7 +1487,11 @@ const AppContent = () => {
             badgeClassName: categoryMeta.badgeClassName,
             numberClassName: categoryMeta.numberClassName,
             readChunkId: citation?.chunk_id || null,
-            viewPdfUrl: citation?.file_url || fallback.url || null
+            viewPdfUrl: buildReferencePdfUrl(
+                citation?.file_url || fallback.url || null,
+                citation?.pdf_page_number,
+                citation?.page_number
+            )
         };
     };
 


### PR DESCRIPTION
## Summary
- return `pdf_page_number` from the agent router for /aibot citation results
- build /aibot `View PDF` links from `pdf_page_number ?? page_number`
- keep `page_number` as the human-visible citation page in the UI

## Why
Home-page search results already distinguish logical book page numbers from physical PDF page numbers. This change makes the /aibot path behave the same way so multi-page/two-up PDFs open on the correct page.
